### PR TITLE
Switch to Ubuntu 22.04 and latest Runner release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:21.04 AS builder
+FROM ubuntu:22.04 AS builder
 
-ARG RUNNER_VERSION="2.284.0"
+ARG RUNNER_VERSION="2.301.1"
 
 WORKDIR /build
 
@@ -19,7 +19,7 @@ RUN apt-get update &&\
 
 
 
-FROM ubuntu:21.04 AS actions-runer
+FROM ubuntu:22.04 AS actions-runer
 
 COPY --from=builder /opt /opt
 COPY --from=builder /build/gcc-arm-none-eabi-9-2020-q2-update/bin /bin


### PR DESCRIPTION
Github is now using 22.04 for `ubuntu-latest`
I don't understand how Ubuntu does releases, but apparently 21.04 doesn't have a release anymore, so apt commands were failing. Do they just remove the release from the package server if it's not LTS? 22.04 is LTS so it should stick around I guess?