### PR TITLE
Big changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ COPY start.sh /opt/start.sh
 
 ADD https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz /build/
 
-ADD https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 /build/
+ADD https://github.com/rusefi/build_support/raw/master/rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz /build/
 
 RUN apt-get update &&\
-    apt-get install bzip2 &&\
+    apt-get install xz-utils &&\
     mkdir -p /opt/actions-runner &&\
     tar -xf ./actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz -C /opt/actions-runner/ &&\
-    tar -xf gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 &&\
+    tar -xf rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz &&\
     chmod +x /opt/start.sh
 
 
@@ -22,7 +22,7 @@ RUN apt-get update &&\
 FROM ubuntu:22.04 AS actions-runer
 
 COPY --from=builder /opt /opt
-COPY --from=builder /build/gcc-arm-none-eabi-9-2020-q2-update/bin /bin
+COPY --from=builder /build/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin /bin
 
 RUN useradd -m -g sudo docker &&\
     apt-get update -y &&\
@@ -48,6 +48,7 @@ RUN useradd -m -g sudo docker &&\
     lsb-release \
     wget \
     file \
+    netbase \
     && apt-get autoremove -y && apt-get clean -y &&\
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&\
     echo 'APT::Get::Assume-Yes "true";' >/etc/apt/apt.conf.d/90forceyes &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN useradd -m -g sudo docker &&\
     time \
     lsb-release \
     wget \
+    file \
     && apt-get autoremove -y && apt-get clean -y &&\
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&\
     echo 'APT::Get::Assume-Yes "true";' >/etc/apt/apt.conf.d/90forceyes &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ COPY start.sh /opt/start.sh
 
 ADD https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz /build/
 
-ADD https://github.com/rusefi/build_support/raw/master/rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz /build/
+ADD https://raw.githubusercontent.com/chuckwagoncomputing/rusefi/dl-toolkit/firmware/provide_gcc.sh /build/
 
 RUN apt-get update &&\
-    apt-get install xz-utils &&\
+    apt-get -y install curl xz-utils &&\
     mkdir -p /opt/actions-runner &&\
     tar -xf ./actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz -C /opt/actions-runner/ &&\
-    tar -xf rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz &&\
+    bash provide_gcc.sh &&\
     chmod +x /opt/start.sh
 
 
@@ -22,7 +22,7 @@ RUN apt-get update &&\
 FROM ubuntu:22.04 AS actions-runer
 
 COPY --from=builder /opt /opt
-COPY --from=builder /build/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin /bin
+COPY --from=builder /tmp/rusefi-provide_gcc /tmp/rusefi-provide_gcc
 
 RUN useradd -m -g sudo docker &&\
     apt-get update -y &&\
@@ -49,10 +49,24 @@ RUN useradd -m -g sudo docker &&\
     wget \
     file \
     netbase \
+    gcc-multilib \
+    g++-multilib \
+    g++-mingw-w64 \
+    gcc-mingw-w64 \
+    sshpass \
+    doxygen \
+    graphviz \
+    lcov \
+    valgrind \
+    python3-pip \
+    python3-tk \
+    scour \
+    librsvg2-bin \
     && apt-get autoremove -y && apt-get clean -y &&\
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&\
     echo 'APT::Get::Assume-Yes "true";' >/etc/apt/apt.conf.d/90forceyes &&\
-    chown -R docker /opt
+    chown -R docker /opt &&\
+    chown -R docker /tmp/rusefi-provide_gcc
 
 WORKDIR /opt
 

--- a/README.md
+++ b/README.md
@@ -6,20 +6,41 @@ To run, first build the image with:
 
 `docker build -t rusefi-ci .`
 
-Then run the newly built image passing `OWNER`, `REPO`, and `REG_TOKEN` (time-limited github actions registration token)
+Then run the newly built image.
 
 ```bash
 docker run --detach \
- --ENV OWNER=ZHoob2004 \
- --ENV REPO=rusefi \
- --ENV REG_TOKEN=<PUT YO TOKEN HERE> \
- --ENV LABELS="linux,self-hosted" \
- rusefi-ci
- ```
-
-Note: the LABELS environment variable is optional, and if omitted will use the default labels as determined by the github runner.
+    -e RUNNER_NAME=test-runner2 \
+    -e RUNNER_LABELS=ubuntu-latest \
+    -e GITHUB_ACCESS_TOKEN=<Personal Access Token> \
+    -e RUNNER_REPOSITORY_URL=https://github.com/ZHoob2004/rusefi \
+    rusefi-ci
+```
 
 Add `--restart=unless-stopped` in order to have the container survive reboots
 
-
 The container uses a persistent volume mounted at /opt/actions-runner. After initial startup, the container will skip registration unless the peristent volume is erased.
+
+## Environment variables
+
+The following environment variables allows you to control the configuration parameters.
+
+| Name | Description | Required/Default value |
+|------|---------------|-------------|
+| RUNNER_REPOSITORY_URL | The runner will be linked to this repository URL | Required if `RUNNER_ORGANIZATION_URL` is not provided |
+| RUNNER_ORGANIZATION_URL | The runner will be linked to this organization URL. *(Self-hosted runners API for organizations is currently in public beta and subject to changes)* | Required if `RUNNER_REPOSITORY_URL` is not provided |
+| GITHUB_ACCESS_TOKEN | Personal Access Token. Used to dynamically fetch a new runner token (recommended, see below). | Required if `RUNNER_TOKEN` is not provided.
+| RUNNER_TOKEN | Runner token provided by GitHub in the Actions page. These tokens are valid for a short period. | Required if `GITHUB_ACCESS_TOKEN` is not provided
+| RUNNER_WORK_DIRECTORY | Runner's work directory | `"_work"`
+| RUNNER_NAME | Name of the runner displayed in the GitHub UI | Hostname of the container
+| RUNNER_LABELS | Extra labels in addition to the default: 'self-hosted,Linux,X64' (based on your OS and architecture) | `""`
+| RUNNER_REPLACE_EXISTING | `"true"` will replace existing runner with the same name, `"false"` will use a random name if there is conflict | `"true"`
+
+## Runner Token
+
+In order to link your runner to your repository/organization, you need to provide a token. There is two way of passing the token :
+
+* via `GITHUB_ACCESS_TOKEN` (recommended), containing a [Personnal Access Token](https://github.com/settings/tokens). This token will be used to dynamically fetch a new runner token, as runner tokens are valid for a short period of time.
+  * For a single-repository runner, your PAT should have `repo` scopes.
+  * For an organization runner, your PAT should have `admin:org` scopes.
+* via `RUNNER_TOKEN`. This token is displayed in the Actions settings page of your organization/repository, when opening the "Add Runner" page.

--- a/start.sh
+++ b/start.sh
@@ -2,10 +2,6 @@
 
 cd /opt/actions-runner
 
-if [[ "$@" == "bash" ]]; then
-    exec $@
-fi
-
 if [[ -z $RUNNER_NAME ]]; then
     echo "RUNNER_NAME environment variable is not set, using '${HOSTNAME}'."
     export RUNNER_NAME=${HOSTNAME}
@@ -74,4 +70,4 @@ else
         --unattended
 fi
 
-exec "$@"
+./run.sh & wait $!

--- a/start.sh
+++ b/start.sh
@@ -1,15 +1,77 @@
 #!/bin/bash
 
-OWNER=$OWNER
-REPO=$REPO
-REG_TOKEN=$REG_TOKEN
-LABELS=${LABELS-"self-hosted"}
-
 cd /opt/actions-runner
 
-
-if [ ! -f ".runner" ]; then
-	./config.sh --url https://github.com/${OWNER}/${REPO} --token ${REG_TOKEN} --labels ${LABELS} --unattended
+if [[ "$@" == "bash" ]]; then
+    exec $@
 fi
 
-./run.sh & wait $!
+if [[ -z $RUNNER_NAME ]]; then
+    echo "RUNNER_NAME environment variable is not set, using '${HOSTNAME}'."
+    export RUNNER_NAME=${HOSTNAME}
+fi
+
+if [[ -z $RUNNER_WORK_DIRECTORY ]]; then
+    echo "RUNNER_WORK_DIRECTORY environment variable is not set, using '_work'."
+    export RUNNER_WORK_DIRECTORY="_work"
+fi
+
+if [[ -z $RUNNER_TOKEN && -z $GITHUB_ACCESS_TOKEN ]]; then
+    echo "Error : You need to set RUNNER_TOKEN (or GITHUB_ACCESS_TOKEN) environment variable."
+    exit 1
+fi
+
+if [[ -z $RUNNER_REPOSITORY_URL && -z $RUNNER_ORGANIZATION_URL ]]; then
+    echo "Error : You need to set the RUNNER_REPOSITORY_URL (or RUNNER_ORGANIZATION_URL) environment variable."
+    exit 1
+fi
+
+if [[ -z $RUNNER_REPLACE_EXISTING ]]; then
+    export RUNNER_REPLACE_EXISTING="true"
+fi
+
+CONFIG_OPTS=""
+if [ "$(echo $RUNNER_REPLACE_EXISTING | tr '[:upper:]' '[:lower:]')" == "true" ]; then
+	CONFIG_OPTS="--replace"
+fi
+
+if [[ -n $RUNNER_LABELS ]]; then
+    CONFIG_OPTS="${CONFIG_OPTS} --labels ${RUNNER_LABELS}"
+fi
+
+if [[ -f ".runner" ]]; then
+    echo "Runner already configured. Skipping config."
+else
+    if [[ ! -z $RUNNER_ORGANIZATION_URL ]]; then
+        SCOPE="orgs"
+        RUNNER_URL="${RUNNER_ORGANIZATION_URL}"
+    else
+        SCOPE="repos"
+        RUNNER_URL="${RUNNER_REPOSITORY_URL}"
+    fi
+
+    if [[ -n $GITHUB_ACCESS_TOKEN ]]; then
+
+        echo "Exchanging the GitHub Access Token with a Runner Token (scope: ${SCOPE})..."
+
+        _PROTO="$(echo "${RUNNER_URL}" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+        _URL="$(echo "${RUNNER_URL/${_PROTO}/}")"
+        _PATH="$(echo "${_URL}" | grep / | cut -d/ -f2-)"
+
+        RUNNER_TOKEN="$(curl -XPOST -fsSL \
+            -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/${SCOPE}/${_PATH}/actions/runners/registration-token" \
+            | jq -r '.token')"
+    fi
+
+    ./config.sh \
+        --url $RUNNER_URL \
+        --token $RUNNER_TOKEN \
+        --name $RUNNER_NAME \
+        --work $RUNNER_WORK_DIRECTORY \
+        $CONFIG_OPTS \
+        --unattended
+fi
+
+exec "$@"


### PR DESCRIPTION
1. Copied some stuff from https://github.com/tcardonne/docker-github-runner/
    - Changes the environment variables passed in (if you don't like this, I can change them back, but there's new ones etc.)
    - Allows you to pass in a Personal Access Token instead of a per-runner key. I don't know if this helps in production, but was a massive time-saver in testing.
    - Checks for necessary environment variables
2. Install everything installed by apt in any workflow
3. Use the same script the firmware workflow does to get the arm-none-eabi Gnu toolchain, so we can stay on the same version (if it's out of date on a running container, it will update when a firmware workflow runs.)
4. Install the same version of Java that is present on Github-hosted runners

As you can see, a lot of these changes are with the goal in mind of reducing the run time of workflows, without caring about the size of the docker image. That seemed to be part of the goal of this image initially, and is what makes the most sense to me, so I took it as far as I could.