### PR TITLE
Docker-in-Docker etc.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04 AS builder
 
-ARG RUNNER_VERSION="2.302.1"
+ARG RUNNER_VERSION="2.312.0"
 
 WORKDIR /build
 
@@ -22,7 +22,7 @@ RUN apt-get update &&\
 FROM ubuntu:22.04 AS actions-runer
 
 COPY --from=builder /opt /opt
-COPY --from=builder /tmp/rusefi-provide_gcc /tmp/rusefi-provide_gcc
+COPY --from=builder /tmp/rusefi-provide_gcc12 /tmp/rusefi-provide_gcc12
 
 ENV JAVA_HOME /usr/lib/jvm/temurin-11-jdk-amd64/
 
@@ -45,6 +45,7 @@ RUN groupadd docker -g $GID &&\
     git \
     gcc \
     make \
+    cmake \
     openjdk-8-jdk-headless \
     ant \
     mtools \
@@ -82,7 +83,7 @@ RUN groupadd docker -g $GID &&\
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&\
     echo 'APT::Get::Assume-Yes "true";' >/etc/apt/apt.conf.d/90forceyes &&\
     chown -R docker /opt &&\
-    chown -R docker /tmp/rusefi-provide_gcc &&\
+    chown -R docker /tmp/rusefi-provide_gcc12 &&\
     update-alternatives --set java /usr/lib/jvm/temurin-11-jdk-amd64/bin/java
 
 # Install Docker CLI

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN groupadd docker -g $GID &&\
     uidmap \
     supervisor \
     iproute2 \
-    openssh \
+    openssh-client \
     && apt-get autoremove -y && apt-get clean -y &&\
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&\
     echo 'APT::Get::Assume-Yes "true";' >/etc/apt/apt.conf.d/90forceyes &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN groupadd docker -g $GID &&\
     wget -O key.gpg https://packages.adoptium.net/artifactory/api/gpg/key/public &&\
     gpg --dearmor -o /usr/share/keyrings/adoptium.gpg key.gpg &&\
     echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" >/etc/apt/sources.list.d/adoptium.list &&\
+    sudo add-apt-repository --yes ppa:kicad/kicad-7.0-releases &&\
     apt-get update -y &&\
     DEBIAN_FRONTEND=noninteractive /opt/actions-runner/bin/installdependencies.sh && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -77,6 +78,7 @@ RUN groupadd docker -g $GID &&\
     iproute2 \
     openssh-client \
     software-properties-common \
+    kicad \
     && apt-get autoremove -y && apt-get clean -y &&\
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&\
     echo 'APT::Get::Assume-Yes "true";' >/etc/apt/apt.conf.d/90forceyes &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN groupadd docker -g $GID &&\
     wget -O key.gpg https://packages.adoptium.net/artifactory/api/gpg/key/public &&\
     gpg --dearmor -o /usr/share/keyrings/adoptium.gpg key.gpg &&\
     echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" >/etc/apt/sources.list.d/adoptium.list &&\
-    sudo add-apt-repository --yes ppa:kicad/kicad-7.0-releases &&\
+    add-apt-repository --yes ppa:kicad/kicad-7.0-releases &&\
     apt-get update -y &&\
     DEBIAN_FRONTEND=noninteractive /opt/actions-runner/bin/installdependencies.sh && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ RUN groupadd docker -g $GID &&\
     supervisor \
     iproute2 \
     openssh-client \
+    software-properties-common \
     && apt-get autoremove -y && apt-get clean -y &&\
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&\
     echo 'APT::Get::Assume-Yes "true";' >/etc/apt/apt.conf.d/90forceyes &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,10 @@ COPY --from=builder /tmp/rusefi-provide_gcc /tmp/rusefi-provide_gcc
 
 ENV JAVA_HOME /usr/lib/jvm/temurin-11-jdk-amd64/
 
-RUN useradd -m -g sudo -u 1001 docker &&\
+ARG GID=1000
+
+RUN groupadd docker -g $GID &&\
+    useradd -m -g docker -G sudo docker &&\
     apt-get update -y &&\
     apt-get install -y wget gpg &&\
     wget -O key.gpg https://packages.adoptium.net/artifactory/api/gpg/key/public &&\
@@ -71,6 +74,8 @@ RUN useradd -m -g sudo -u 1001 docker &&\
     temurin-11-jdk \
     uidmap \
     supervisor \
+    iproute2 \
+    openssh \
     && apt-get autoremove -y && apt-get clean -y &&\
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&\
     echo 'APT::Get::Assume-Yes "true";' >/etc/apt/apt.conf.d/90forceyes &&\
@@ -89,9 +94,7 @@ RUN curl -L -o /usr/local/bin/docker-compose \
     chmod +x /usr/local/bin/docker-compose
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-RUN chmod 644 /etc/supervisor/conf.d/supervisord.conf &&\
-    chmod u-s /usr/bin/newuidmap &&\
-    chmod u-s /usr/bin/newgidmap
+RUN chmod 644 /etc/supervisor/conf.d/supervisord.conf
 
 WORKDIR /opt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04 AS builder
 
-ARG RUNNER_VERSION="2.301.1"
+ARG RUNNER_VERSION="2.302.1"
 
 WORKDIR /build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ARG GID=1000
 RUN groupadd docker -g $GID &&\
     useradd -m -g docker -G sudo docker &&\
     apt-get update -y &&\
-    apt-get install -y wget gpg &&\
+    apt-get install -y wget gpg software-properties-common &&\
     wget -O key.gpg https://packages.adoptium.net/artifactory/api/gpg/key/public &&\
     gpg --dearmor -o /usr/share/keyrings/adoptium.gpg key.gpg &&\
     echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" >/etc/apt/sources.list.d/adoptium.list &&\
@@ -77,7 +77,6 @@ RUN groupadd docker -g $GID &&\
     supervisor \
     iproute2 \
     openssh-client \
-    software-properties-common \
     kicad \
     && apt-get autoremove -y && apt-get clean -y &&\
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&\

--- a/README.md
+++ b/README.md
@@ -44,3 +44,28 @@ In order to link your runner to your repository/organization, you need to provid
   * For a single-repository runner, select the repository under "Only select repositories", then under "Repository Permissions" set "Administration" to read-write.
   * For an organization runner, select the repository and set "Organization self hosted runners"to read-write.
 * via `RUNNER_TOKEN`. This token is displayed in the Actions settings page of your organization/repository, when opening the "Add Runner" page.
+
+## Helper Functions
+
+If you stop and start workes often, you may find it useful to have a function for starting workers. I have added the below functions to my .bashrc:
+
+```bash
+ghatoken ()
+{
+ echo -n "Paste token:"
+ read TOKEN
+ KEY=$(echo "$TOKEN" | openssl enc -aes-256-cbc -a | tr -d '\n')
+ perl -pi -e 's#(?<=KEY=").*?(?="\sd)#'"$KEY"'#' ~/.bashrc
+}
+
+gha ()
+{
+  KEY="" docker run -it --privileged -e RUNNER_NAME=runner-$1 -e RUNNER_LABELS=ubuntu-latest -e GITHUB_ACCESS_TOKEN=$(echo "$KEY" | openssl enc -aes-256-cbc -a -d) -e RUNNER_REPOSITORY_URL=https://github.com/<github user>/rusefi rusefi-ci
+}
+```
+
+Replace `<github user>` with your own username if you are running on your own fork.
+If you are running an organization-level runner, you will need to replace `RUNNER_REPOSITORY_URL` with `RUNNER_ORGANIZATION_URL`.
+
+Once the functions are in your .bashrc, and you have sourced your .bashrc, by opening a new shell or by running `. ~/.bashrc`,
+run `ghatoken`, paste in your PAT, and enter a password. This password will be used every time you start a runner.

--- a/README.md
+++ b/README.md
@@ -58,12 +58,13 @@ ghatoken ()
  echo -n "Paste token:"
  read TOKEN
  KEY=$(echo "$TOKEN" | openssl enc -aes-256-cbc -a | tr -d '\n')
- perl -pi -e 's#(?<=KEY=").*?(?="\sd)#'"$KEY"'#' ~/.bashrc
+ perl -pi -e 's#(?<=TOKEN=\$\(echo\s").*?(?="\s\|)#'"$KEY"'#' $(realpath ~/.bashrc)
 }
 
 gha ()
 {
-  KEY="" docker run -it --privileged -e RUNNER_NAME=runner-$1 -e RUNNER_LABELS=ubuntu-latest -e GITHUB_ACCESS_TOKEN=$(echo "$KEY" | openssl enc -aes-256-cbc -a -d) -e RUNNER_REPOSITORY_URL=https://github.com/<github user>/rusefi rusefi-ci
+  TOKEN=$(echo "U2FsdGVkX1/bq53NjBMtWxIiCE0gzVtrqzPjgAlyPziyVcc3OCkF0HUrg1LcMTfb74Yrs7p2HBmISrqYSOZF2B1jZ1y6hvF4I7/GyXUFFTKMTg7gjJCfjJwo0ShFTGBqan/xWZiZKqIUsrHPN5V3EA==" | openssl enc -aes-256-cbc -a -d)
+  docker run -it --privileged -e RUNNER_NAME=runner-$1 -e RUNNER_LABELS=ubuntu-latest -e GITHUB_ACCESS_TOKEN="$TOKEN" -e RUNNER_REPOSITORY_URL=https://github.com/<github user>/rusefi rusefi-ci
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To run, first build the image with:
 Then run the newly built image.
 
 ```bash
-docker run --detach \
+docker run --detach --privileged \
     -e RUNNER_NAME=test-runner2 \
     -e RUNNER_LABELS=ubuntu-latest \
     -e GITHUB_ACCESS_TOKEN=<Personal Access Token> \

--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ ghatoken ()
 gha ()
 {
   if ! TOKEN=$(echo "" | openssl enc -aes-256-cbc -a -d -pbkdf2 ); then echo "Error encoding token"; return 1; fi
-  docker run -it --privileged -e RUNNER_NAME=runner-$1 -e RUNNER_LABELS=ubuntu-latest -e GITHUB_ACCESS_TOKEN="$TOKEN" -e RUNNER_REPOSITORY_URL=https://github.com/chuckwagoncomputing/rusefi rusefi-ci
+  NAME="runner-$1"
+  IMAGE_HASH=$(docker image inspect rusefi-ci --format "{{.Id}}" 2>/dev/null)
+  if CONTAINER_HASH=$(docker container inspect $NAME --format "{{.Image}}" 2>/dev/null) && [ "$IMAGE_HASH" = "$CONTAINER_HASH" ]; then
+    docker start -i "$NAME"
+  else
+    docker run -it --privileged -e RUNNER_NAME="$NAME" -e RUNNER_LABELS=ubuntu-latest -e GITHUB_ACCESS_TOKEN="$TOKEN" -e RUNNER_REPOSITORY_URL=https://github.com/<github user>/rusefi --name $NAME rusefi-ci
+  fi
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ docker run --detach --privileged \
     -e RUNNER_NAME=test-runner2 \
     -e RUNNER_LABELS=ubuntu-latest \
     -e GITHUB_ACCESS_TOKEN=<Personal Access Token> \
-    -e RUNNER_REPOSITORY_URL=https://github.com/ZHoob2004/rusefi \
+    -e RUNNER_REPOSITORY_URL=https://github.com/<github user>/rusefi \
     rusefi-ci
 ```
+Replace `<github user>` with your own username if you are running on your own fork.
+If you are running an organization-level runner, you will need to replace `RUNNER_REPOSITORY_URL` with `RUNNER_ORGANIZATION_URL`.
+
 
 Add `--restart=unless-stopped` in order to have the container survive reboots
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ gha ()
   if CONTAINER_HASH=$(docker container inspect $NAME --format "{{.Image}}" 2>/dev/null) && [ "$IMAGE_HASH" = "$CONTAINER_HASH" ]; then
     docker start -i "$NAME"
   else
+    if docker container inspect "$NAME" >/dev/null 2>/dev/null; then
+      docker rm "$NAME"
+    fi
     docker run -it --privileged -e RUNNER_NAME="$NAME" -e RUNNER_LABELS=ubuntu-latest -e GITHUB_ACCESS_TOKEN="$TOKEN" -e RUNNER_REPOSITORY_URL=https://github.com/<github user>/rusefi --name $NAME rusefi-ci
   fi
 }

--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ ghatoken ()
 {
  echo -n "Paste token:"
  read TOKEN
- KEY=$(echo "$TOKEN" | openssl enc -aes-256-cbc -a | tr -d '\n')
+ KEY=$(echo "$TOKEN" | openssl enc -aes-256-cbc -a -pbkdf2 | tr -d '\n')
  perl -pi -e 's#(?<=TOKEN=\$\(echo\s").*?(?="\s\|)#'"$KEY"'#' $(realpath ~/.bashrc)
  bash
 }
 
 gha ()
 {
-  if ! TOKEN=$(echo "" | openssl enc -aes-256-cbc -a -d); then echo "Error encoding token"; return 1; fi
+  if ! TOKEN=$(echo "" | openssl enc -aes-256-cbc -a -d -pbkdf2 ); then echo "Error encoding token"; return 1; fi
   docker run -it --privileged -e RUNNER_NAME=runner-$1 -e RUNNER_LABELS=ubuntu-latest -e GITHUB_ACCESS_TOKEN="$TOKEN" -e RUNNER_REPOSITORY_URL=https://github.com/chuckwagoncomputing/rusefi rusefi-ci
 }
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following environment variables allows you to control the configuration para
 
 In order to link your runner to your repository/organization, you need to provide a token. There is two way of passing the token :
 
-* via `GITHUB_ACCESS_TOKEN` (recommended), containing a [Personnal Access Token](https://github.com/settings/tokens). This token will be used to dynamically fetch a new runner token, as runner tokens are valid for a short period of time.
-  * For a single-repository runner, your PAT should have `repo` scopes.
-  * For an organization runner, your PAT should have `admin:org` scopes.
+* via `GITHUB_ACCESS_TOKEN` (recommended), containing a [fine-grained Personnal Access Token](https://github.com/settings/tokens). This token will be used to dynamically fetch a new runner token, as runner tokens are valid for a short period of time.
+  * For a single-repository runner, select the repository under "Only select repositories", then under "Repository Permissions" set "Administration" to read-write.
+  * For an organization runner, select the repository and set "Organization self hosted runners"to read-write.
 * via `RUNNER_TOKEN`. This token is displayed in the Actions settings page of your organization/repository, when opening the "Add Runner" page.

--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ ghatoken ()
  read TOKEN
  KEY=$(echo "$TOKEN" | openssl enc -aes-256-cbc -a | tr -d '\n')
  perl -pi -e 's#(?<=TOKEN=\$\(echo\s").*?(?="\s\|)#'"$KEY"'#' $(realpath ~/.bashrc)
+ bash
 }
 
 gha ()
 {
-  TOKEN=$(echo "U2FsdGVkX1/bq53NjBMtWxIiCE0gzVtrqzPjgAlyPziyVcc3OCkF0HUrg1LcMTfb74Yrs7p2HBmISrqYSOZF2B1jZ1y6hvF4I7/GyXUFFTKMTg7gjJCfjJwo0ShFTGBqan/xWZiZKqIUsrHPN5V3EA==" | openssl enc -aes-256-cbc -a -d)
-  docker run -it --privileged -e RUNNER_NAME=runner-$1 -e RUNNER_LABELS=ubuntu-latest -e GITHUB_ACCESS_TOKEN="$TOKEN" -e RUNNER_REPOSITORY_URL=https://github.com/<github user>/rusefi rusefi-ci
+  if ! TOKEN=$(echo "" | openssl enc -aes-256-cbc -a -d); then echo "Error encoding token"; return 1; fi
+  docker run -it --privileged -e RUNNER_NAME=runner-$1 -e RUNNER_LABELS=ubuntu-latest -e GITHUB_ACCESS_TOKEN="$TOKEN" -e RUNNER_REPOSITORY_URL=https://github.com/chuckwagoncomputing/rusefi rusefi-ci
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,3 +72,6 @@ If you are running an organization-level runner, you will need to replace `RUNNE
 
 Once the functions are in your .bashrc, and you have sourced your .bashrc, by opening a new shell or by running `. ~/.bashrc`,
 run `ghatoken`, paste in your PAT, and enter a password. This password will be used every time you start a runner.
+
+After you have run `ghatoken`, you can now start runners with `gha <id>`. I use sequential ids, e.g. `gha 1`, `gha 2`, etc,
+but you may name them however you like.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This dockerfile will automatically download and configure the github actions sel
 
 To run, first build the image with:
 
-`docker build -t rusefi-ci .`
+`docker build --build-arg GID=$(getent group docker | cut -d ':' -f 3) -t rusefi-ci .`
 
 Then run the newly built image.
 

--- a/README.md
+++ b/README.md
@@ -83,3 +83,5 @@ run `ghatoken`, paste in your PAT, and enter a password. This password will be u
 
 After you have run `ghatoken`, you can now start runners with `gha <id>`. I use sequential ids, e.g. `gha 1`, `gha 2`, etc,
 but you may name them however you like.
+
+Note that these helper functions start the runner in interactive mode. If you prefer, you can remove the `-i` in `docker start -i` and replace the `-it` in `docker run -it` with `--detach`.

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+if [[ "$@" == "bash" ]]; then
+    exec $@
+fi
+
+export XDG_RUNTIME_DIR=$HOME/.docker/xrd
+rm -rf $XDG_RUNTIME_DIR
+mkdir -p $XDG_RUNTIME_DIR
+PATH=/usr/bin:/sbin:/usr/sbin:$PATH dockerd-rootless.sh
+
 cd /opt/actions-runner
 
 if [[ -z $RUNNER_NAME ]]; then
@@ -70,4 +79,4 @@ else
         --unattended
 fi
 
-./run.sh & wait $!
+exec "$@"

--- a/start.sh
+++ b/start.sh
@@ -4,6 +4,8 @@ if [[ "$@" == "bash" ]]; then
     exec $@
 fi
 
+ulimit -n 1024
+
 export XDG_RUNTIME_DIR=$HOME/.docker/run
 export DOCKER_HOST=unix:///home/docker/.docker/run/docker.sock
 rm -rf $XDG_RUNTIME_DIR

--- a/start.sh
+++ b/start.sh
@@ -4,10 +4,11 @@ if [[ "$@" == "bash" ]]; then
     exec $@
 fi
 
-export XDG_RUNTIME_DIR=$HOME/.docker/xrd
+export XDG_RUNTIME_DIR=$HOME/.docker/run
+export DOCKER_HOST=unix:///home/docker/.docker/run/docker.sock
 rm -rf $XDG_RUNTIME_DIR
 mkdir -p $XDG_RUNTIME_DIR
-PATH=/usr/bin:/sbin:/usr/sbin:$PATH dockerd-rootless.sh
+PATH=/usr/bin:/sbin:/usr/sbin:$PATH dockerd-rootless.sh >/opt/docker.log 2>/opt/docker.log &
 
 cd /opt/actions-runner
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,13 @@
+[supervisord]
+user=docker
+nodaemon=true
+logfile=/dev/fd/1
+logfile_maxbytes=0
+loglevel=error
+
+[program:runner]
+directory=/opt/actions-runner
+command=/opt/actions-runner/bin/runsvc.sh
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true


### PR DESCRIPTION
1. Install Docker in the container for Actions that use a Docker container.
   Right now the new reusable [interactive pinout generator](https://github.com/chuckwagoncomputing/interactive-pinout) is the only thing that uses this.
2. Use supervisord. I don't know if this is actually necessary; I added it while trying to get Docker working, and it's nice because now I can Ctrl+C out of containers.
3. install openssh-client - lots of stuff needs this, I don't know why I didn't notice it missing before.

Caveat:
Running Docker-in-Docker requires the outside container to be run with `--privileged`

Notes:
To make this work, you have to pass the ID of the docker group at container build time so that the docker group on the host and the docker group in the container have matching IDs.
This whole setup seems like a bit of a pile of cards and I don't really like it. I don't know how Github does it, but as far as I can tell, this is the way to do it.